### PR TITLE
Add declarative geoblacklight record

### DIFF
--- a/kepler/descriptors.py
+++ b/kepler/descriptors.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import decimal
+import arrow
+from kepler.exceptions import InvalidDataError
+
+
+class RecordMeta(type):
+    def __new__(cls, clsname, bases, methods):
+        for k, v in methods.items():
+            if isinstance(v, Descriptor):
+                v.name = k
+        return type.__new__(cls, clsname, bases, methods)
+
+
+class Descriptor(object):
+    def __init__(self, name=None, **opts):
+        self.name = name
+        for k, v in opts.items():
+            setattr(self, k, v)
+
+    def __set__(self, instance, value):
+        instance.__dict__[self.name] = value
+
+
+class Default(Descriptor):
+    def __get__(self, instance, owner):
+        try:
+            return instance.__dict__.get(self.name, self.default)
+        except AttributeError:
+            return instance.__dict__.get(self.name)
+
+
+class Enum(Default):
+    def __set__(self, instance, value):
+        if value in self.enums:
+            super(Enum, self).__set__(instance, value)
+        else:
+            raise InvalidDataError(self.name, value)
+
+
+class String(Default):
+    def __init__(self, name=None, **opts):
+        defaults = {'strip_ws': True}
+        defaults.update(opts)
+        super(String, self).__init__(name, **defaults)
+
+    def __set__(self, instance, value):
+        if self.strip_ws: value = value.strip()
+        super(String, self).__set__(instance, value)
+
+
+class Decimal(Default):
+    def __set__(self, instance, value):
+        super(Decimal, self).__set__(instance, decimal.Decimal(value))
+
+
+class DateTime(Descriptor):
+    def __set__(self, instance, value):
+        super(DateTime, self).__set__(instance, arrow.get(value))
+
+    def __get__(self, instance, owner):
+        try:
+            return instance.__dict__.get(self.name, arrow.get(self.default))
+        except AttributeError:
+            return instance.__dict__.get(self.name)
+
+
+class Integer(Default):
+    def __set__(self, instance, value):
+        super(Integer, self).__set__(instance, int(value))
+
+
+class Set(Descriptor):
+    def __set__(self, instance, value):
+        super(Set, self).__set__(instance, set(value))
+
+    def __get__(self, instance, owner):
+        if instance.__dict__.get(self.name) is None:
+            self.__set__(instance, set())
+        return instance.__dict__.get(self.name)
+
+
+class Dictionary(Descriptor):
+    def __get__(self, instance, owner):
+        if instance.__dict__.get(self.name) is None:
+            self.__set__(instance, dict())
+        return instance.__dict__.get(self.name)

--- a/kepler/exceptions.py
+++ b/kepler/exceptions.py
@@ -6,3 +6,10 @@ class UnsupportedFormat(Exception):
 
     def __init__(self, mimetype):
         self.mimetype = mimetype
+
+
+class InvalidDataError(Exception):
+    def __init__(self, field, value):
+        super(InvalidDataError, self).__init__(field, value)
+        self.field = field
+        self.value = value

--- a/kepler/records.py
+++ b/kepler/records.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from six import add_metaclass
+import arrow
+import json
+from kepler.descriptors import *
+
+
+@add_metaclass(RecordMeta)
+class BaseRecord(object):
+    pass
+
+
+class GeoRecord(BaseRecord):
+    """Defines a GeoBlacklight record.
+
+    A record's fields can be initialized through keyword arguments.
+
+    :param kwargs: initial field values
+    """
+
+    uuid = String()
+    dc_identifier_s = String()
+    dc_title_s = String()
+    dc_description_s = String()
+    dc_rights_s = Enum(enums=['Public', 'Restricted'])
+    dct_provenance_s = String()
+    dct_references_s = Dictionary()
+    layer_id_s = String()
+    layer_geom_type_s = Enum(enums=['Point', 'Line', 'Polygon', 'Raster',
+                                'Scanned Map', 'Paper Map', 'Mixed'])
+    layer_modified_dt = DateTime(default=arrow.now())
+    layer_slug_s = String()
+    solr_year_i = Integer()
+    dc_creator_sm = Set()
+    dc_format_s = String()
+    dc_language_s = String()
+    dc_publisher_s = String()
+    dc_subject_sm = Set()
+    dc_type_s = Enum(enums=['Dataset', 'Image', 'PhysicalObject'])
+    dct_spatial_sm = Set()
+    dct_temporal_sm = Set()
+    dct_issued_dt = String()
+    dct_isPartOf_sm = Set()
+
+    _bbox_w = Decimal()
+    _bbox_n = Decimal()
+    _bbox_e = Decimal()
+    _bbox_s = Decimal()
+    _lat = Decimal()
+    _lon = Decimal()
+
+    def __init__(self, **kwargs):
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+    @property
+    def georss_box_s(self):
+        bounds = (self._bbox_s, self._bbox_w, self._bbox_n, self._bbox_e)
+        if None in bounds:
+            return None
+        return "%s %s %s %s" % bounds
+
+    @property
+    def solr_bbox(self):
+        bounds = (self._bbox_w, self._bbox_s, self._bbox_e, self._bbox_n)
+        if None in bounds:
+            return None
+        return "%s %s %s %s" % bounds
+
+    @property
+    def solr_geom(self):
+        bounds = (self._bbox_w, self._bbox_e, self._bbox_n, self._bbox_s)
+        if None in bounds:
+            return None
+        return "ENVELOPE(%s, %s, %s, %s)" % bounds
+
+    @property
+    def georss_point_s(self):
+        point = (self._lat, self._lon)
+        if None in point:
+            return None
+        return "%s %s" % point
+
+    def as_dict(self):
+        """Return record as a dictionary.
+
+        Each field will either be a value of the specified field type or
+        ``None``, except in the cases of ``Set()``s and ``Dictionary()``s,
+        which will be empty constructs of the corresponding type.
+
+        The ``dct_references_s`` field, if not ``None``, will be
+        represented as a valid JSON string.
+
+        :rtype: dictionary
+        """
+
+        if self.dct_references_s:
+            references = json.dumps(self.dct_references_s)
+        else:
+            references = None
+        return {
+            'uuid': self.uuid,
+            'dc_identifier_s': self.dc_identifier_s,
+            'dc_title_s': self.dc_title_s,
+            'dc_description_s': self.dc_description_s,
+            'dc_rights_s': self.dc_rights_s,
+            'dct_provenance_s': self.dct_provenance_s,
+            'dct_references_s': references,
+            'georss_box_s': self.georss_box_s,
+            'layer_id_s': self.layer_id_s,
+            'layer_geom_type_s': self.layer_geom_type_s,
+            'layer_modified_dt': self.layer_modified_dt,
+            'layer_slug_s': self.layer_slug_s,
+            'solr_bbox': self.solr_bbox,
+            'solr_geom': self.solr_geom,
+            'solr_year_i': self.solr_year_i,
+            'dc_creator_sm': self.dc_creator_sm,
+            'dc_format_s': self.dc_format_s,
+            'dc_language_s': self.dc_language_s,
+            'dc_publisher_s': self.dc_publisher_s,
+            'dc_subject_sm': self.dc_subject_sm,
+            'dc_type_s': self.dc_type_s,
+            'dct_spatial_sm': self.dct_spatial_sm,
+            'dct_temporal_sm': self.dct_temporal_sm,
+            'dct_issued_dt': self.dct_issued_dt,
+            'dct_isPartOf_sm': self.dct_isPartOf_sm,
+            'georss_point_s': self.georss_point_s,
+        }

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,12 +8,14 @@ SQLAlchemy==0.9.8
 WebOb==1.4
 WebTest==2.0.17
 Werkzeug==0.9.6
+arrow==0.5.0
 beautifulsoup4==4.3.2
 blessings==1.6
 colour-runner==0.0.4
 itsdangerous==0.24
 mock==1.0.1
 pymarc==3.0.3
+python-dateutil==2.4.0
 requests==2.5.1
 six==1.9.0
 waitress==0.8.9

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from tests import unittest
+import arrow
+import json
+from kepler.records import GeoRecord
+from kepler.exceptions import InvalidDataError
+
+
+class GeoRecordTestCase(unittest.TestCase):
+    def testRecordInitializesFromData(self):
+        r = GeoRecord(dc_rights_s='Public')
+        self.assertEqual(r.dc_rights_s, 'Public')
+
+    def testEnumRaisesExceptionForUnknownValue(self):
+        with self.assertRaises(InvalidDataError):
+            GeoRecord(dc_rights_s='Level 8')
+
+    def testStringFieldStripsWhitespaceByDefault(self):
+        r = GeoRecord(dc_title_s='Geothermal resources of New Mexico ')
+        self.assertEqual(r.dc_title_s, 'Geothermal resources of New Mexico')
+
+    def testGeoRssConstructsRssString(self):
+        r = GeoRecord(_bbox_w='-20.5', _bbox_e='20', _bbox_s='-10',
+                      _bbox_n='10.0')
+        self.assertEqual(r.georss_box_s, '-10 -20.5 10.0 20')
+
+    def testDateTimeConstructsDateTime(self):
+        r = GeoRecord(layer_modified_dt='2015-01-01T12:12:12Z')
+        self.assertEqual(r.layer_modified_dt.year, 2015)
+
+    def testDateTimeUsesDefault(self):
+        r = GeoRecord()
+        self.assertEqual(r.layer_modified_dt.year, arrow.now().year)
+
+    def testSolrBboxConstructsBboxString(self):
+        r = GeoRecord(_bbox_w='-20.5', _bbox_e='20', _bbox_s='-10',
+                      _bbox_n='10.0')
+        self.assertEqual(r.solr_bbox, '-20.5 -10 20 10.0')
+
+    def testSolrGeomConstructsGeomString(self):
+        r = GeoRecord(_bbox_w='-20.5', _bbox_e='20', _bbox_s='-10',
+                      _bbox_n='10.0')
+        self.assertEqual(r.solr_geom, 'ENVELOPE(-20.5, 20, 10.0, -10)')
+
+    def testIntegerFieldConvertsToInteger(self):
+        r = GeoRecord(solr_year_i='1999')
+        self.assertEqual(r.solr_year_i, 1999)
+
+    def testSetFieldRemovesDuplicates(self):
+        r = GeoRecord(dc_creator_sm=['Bubbles', 'Bubbles'])
+        self.assertEqual(r.dc_creator_sm, set(['Bubbles']))
+
+    def testGeoRssPointConstructsRssString(self):
+        r = GeoRecord(_lat='45', _lon='-180')
+        self.assertEqual(r.georss_point_s, '45 -180')
+
+    def testAsDictReturnsReferencesAsJson(self):
+        references = {
+            'http://schema.org/Person': 'Britney Spears',
+        }
+        r = GeoRecord(dct_references_s=references)
+        self.assertEqual(r.as_dict().get('dct_references_s'),
+                         json.dumps(references))
+
+    def testGeoRecordCanBeRepresentedAsDictionary(self):
+        time = arrow.now()
+        r = GeoRecord(uuid='0-8-3', dc_title_s='Today, in the world of cats',
+                      _lat='-23', _lon='97', layer_modified_dt=time)
+        self.assertEqual(dict((k, v) for k,v in r.as_dict().items() if v),
+            {'uuid': '0-8-3', 'dc_title_s': 'Today, in the world of cats',
+             'georss_point_s': '-23 97', 'layer_modified_dt': time})


### PR DESCRIPTION
This adds support for declaratively defining a record with some
basic assurance about values for each field.

Partially addresses #11 through computed properties.