### PR TITLE
Make shapefile upload atomic

### DIFF
--- a/kepler/jobs.py
+++ b/kepler/jobs.py
@@ -48,8 +48,10 @@ class UploadJob(object):
 class ShapefileUploadJob(UploadJob):
     def run(self):
         url = current_app.config['GEOSERVER_URL']
-        mgr = GeoServerServiceManager(url)
-        mgr.upload(self.data)
+        workspace = current_app.config['GEOSERVER_WORKSPACE']
+        datastore = current_app.config['GEOSERVER_DATASTORE']
+        mgr = GeoServerServiceManager(url, workspace, datastore)
+        mgr.upload(self.data, self.data.mimetype)
 
     def create_record(self, metadata):
         records = FgdcParser(metadata)

--- a/kepler/services/geoserver.py
+++ b/kepler/services/geoserver.py
@@ -10,10 +10,16 @@ except ImportError:
 class GeoServerServiceManager(object):
     def __init__(self, url, workspace, datastore):
         url = url.rstrip('/') + '/'
-        self.url = urljoin(url,
-            "rest/workspaces/%s/datastores/%s/file.shp" % (workspace, datastore))
+        self.base_url = urljoin(url,
+            "rest/workspaces/%s/datastores/%s/" % (workspace, datastore))
 
     def upload(self, fstream, mimetype):
         headers = {'Content-type': mimetype}
-        r = requests.put(self.url, data=fstream, headers=headers)
+        url = "%sfile.shp" % self.base_url
+        r = requests.put(url, data=fstream, headers=headers)
+        r.raise_for_status()
+
+    def delete(self, filename):
+        url = "%sfeaturetypes/%s?recurse=true" % (self.base_url, filename)
+        r = requests.delete(url)
         r.raise_for_status()

--- a/kepler/services/geoserver.py
+++ b/kepler/services/geoserver.py
@@ -1,11 +1,19 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import requests
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
 
 class GeoServerServiceManager(object):
-    def __init__(self, url):
-        self.url = url
+    def __init__(self, url, workspace, datastore):
+        url = url.rstrip('/') + '/'
+        self.url = urljoin(url,
+            "rest/workspaces/%s/datastores/%s/file.shp" % (workspace, datastore))
 
-    def upload(self, fstream):
-        r = requests.put(self.url, fstream)
+    def upload(self, fstream, mimetype):
+        headers = {'Content-type': mimetype}
+        r = requests.put(self.url, data=fstream, headers=headers)
         r.raise_for_status()

--- a/kepler/settings.py
+++ b/kepler/settings.py
@@ -15,6 +15,7 @@ class TestConfig(DefaultConfig):
     TESTING = True
     DEBUG = True
     SQLALCHEMY_DATABASE_URI = 'sqlite://'
-    GEOSERVER_URL = 'http://example.com/'
+    GEOSERVER_URL = 'http://example.com/geoserver'
     GEOSERVER_WORKSPACE = 'mit'
+    GEOSERVER_DATASTORE = 'data'
     SOLR_URL = 'http://localhost:8983/solr/geoblacklight/'

--- a/tests/test_upload_job.py
+++ b/tests/test_upload_job.py
@@ -88,11 +88,11 @@ class UploadJobTestCase(JobTestCase):
 class ShapefileUploadJobTestCase(JobTestCase):
     @patch('requests.put')
     def testRunUploadsShapefileToGeoserver(self, mock):
-        url = current_app.config['GEOSERVER_URL']
-        file = io.BytesIO(u'Test file'.encode('utf-8'))
-        job = ShapefileUploadJob(job=Job(), data=file)
+        job = ShapefileUploadJob(job=Job(), data=self.data)
         job.run()
-        mock.assert_called_with(url, file)
+        mock.assert_called_with(
+            'http://example.com/geoserver/rest/workspaces/mit/datastores/data/file.shp',
+            data=self.data, headers={'Content-type': 'application/zip'})
 
     def testCreateRecordReturnsMetadataRecord(self):
         metadata = io.open('tests/data/shapefile/fgdc.xml', encoding='utf-8')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -15,7 +15,8 @@ class IngestTestCase(BaseTestCase):
         ]
 
     @patch('requests.put')
-    def testIngestPostReturns202OnSuccess(self, req):
+    @patch('pysolr.Solr.add')
+    def testIngestPostReturns202OnSuccess(self, mock_solr, mock_geoserver):
         r = self.app.post('/ingest/', upload_files=self.upload_files)
         self.assertEqual(r.status_code, 202)
 
@@ -33,7 +34,8 @@ class IngestTestCase(BaseTestCase):
             self.assertEqual(r.status_code, 415)
 
     @patch('requests.put')
-    def testIngestCompletesJobOnSuccess(self, req):
+    @patch('pysolr.Solr.add')
+    def testIngestCompletesJobOnSuccess(self, mock_solr, mock_geoserver):
         with patch('kepler.jobs.UploadJob.complete') as mock:
             self.app.post('/ingest/', upload_files=self.upload_files)
             self.assertTrue(mock.called)


### PR DESCRIPTION
Closes #18. Solr indexing is only carried out if the GeoServer upload
succeedes. If the Solr indexing fails, an attempt is made to delete the
uploaded shapefile from GeoServer.