### PR TITLE
Move record creation out of UploadJob

### DIFF
--- a/kepler/records.py
+++ b/kepler/records.py
@@ -8,6 +8,13 @@ from slugify import slugify
 from kepler.descriptors import *
 
 
+def create_record(metadata, parser, **kwargs):
+    records = parser(metadata)
+    record = next(iter(records))
+    record.update(kwargs)
+    return MitRecord(**record)
+
+
 def rights_mapper(term):
     """Maps access rights from FGDC to canonical GeoBlacklight value."""
     if term.lower().startswith('unrestricted'):

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,12 +1,35 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from tests import unittest
+import io
 import arrow
 import json
 import uuid
 from slugify import slugify
-from kepler.records import GeoRecord, MitRecord
+from kepler.records import GeoRecord, MitRecord, create_record
 from kepler.exceptions import InvalidDataError
+from kepler.parsers import FgdcParser
+
+
+class RecordCreationTestCase(unittest.TestCase):
+    def setUp(self):
+        self.metadata = io.open('tests/data/shapefile/fgdc.xml',
+                                encoding='utf-8')
+
+    def tearDown(self):
+        self.metadata.close()
+
+    def testCreateRecordReturnsMetadataRecord(self):
+        record = create_record(self.metadata, FgdcParser)
+        self.assertEqual(record.dc_title_s,
+                         'Bermuda (Geographic Feature Names, 2003)')
+        self.assertEqual(record.dc_rights_s, 'Public')
+
+    def testCreateRecordUsesUserSuppliedValues(self):
+        record = create_record(self.metadata, FgdcParser,
+                               dc_rights_s='Restricted', dct_provenance_s='MIT')
+        self.assertEqual(record.dc_rights_s, 'Restricted')
+        self.assertEqual(record.dct_provenance_s, 'MIT')
 
 
 class GeoRecordTestCase(unittest.TestCase):


### PR DESCRIPTION
Closes #25. Record creation functionality will be used by multiple
kinds of jobs and should be the same aside from a few pieces of data.