### PR TITLE
Use PUT for resource creation

### DIFF
--- a/kepler/ingest/views.py
+++ b/kepler/ingest/views.py
@@ -9,17 +9,17 @@ class IngestView(View):
     def dispatch_request(self, *args, **kwargs):
         if request.method == 'GET':
             return self.show(*args, **kwargs)
-        elif request.method == 'POST':
-            return self.create()
+        elif request.method == 'PUT':
+            return self.create(*args, **kwargs)
 
     def show(self, job_name):
         job = Job.query.filter_by(name=job_name).first_or_404()
         return jsonify(job.as_dict)
 
-    def create(self):
+    def create(self, job_name):
         shapefile = request.files['shapefile']
         metadata = request.files['metadata']
-        job = create_job(data=shapefile, metadata=metadata)
+        job = create_job(name=job_name, data=shapefile, metadata=metadata)
         try:
             job.run()
         except Exception:
@@ -32,6 +32,5 @@ class IngestView(View):
     @classmethod
     def register(cls, app, endpoint, url):
         view_func = cls.as_view(endpoint)
-        app.add_url_rule(url, 'index', view_func=view_func, methods=['POST'])
-        app.add_url_rule('%s<path:job_name>' % url, 'resource', methods=['GET'],
-                         view_func=view_func)
+        app.add_url_rule('%s<path:job_name>' % url, 'resource',
+                         methods=['GET', 'PUT'], view_func=view_func)

--- a/kepler/jobs.py
+++ b/kepler/jobs.py
@@ -10,8 +10,7 @@ from kepler.services.solr import SolrServiceManager
 from kepler.parsers import FgdcParser
 from kepler.records import create_record
 
-def create_job(data, metadata=None):
-    name = data.filename
+def create_job(name, data=None, metadata=None):
     job = Job(name=name, status=u'PENDING')
     db.session.add(job)
     db.session.commit()

--- a/tests/test_upload_job.py
+++ b/tests/test_upload_job.py
@@ -21,32 +21,32 @@ class JobTestCase(BaseTestCase):
 
 class JobFactoryTestCase(JobTestCase):
     def testCreateJobCreatesJob(self):
-        create_job(self.data)
+        create_job(u'LEURENT', self.data)
         self.assertEqual(Job.query.count(), 1)
 
     def testJobIsCreatedWithPendingStatus(self):
-        create_job(self.data)
+        create_job(u'RUMBLUS', self.data)
         job = Job.query.first()
         self.assertEqual(job.status, 'PENDING')
 
     def testCreateJobReturnsJob(self):
-        job = create_job(self.data)
+        job = create_job(u'KHOLER', self.data)
         self.assertIsInstance(job, UploadJob)
 
     def testCreateJobCreatesShapefileJobFromMimetype(self):
-        job = create_job(self.data)
+        job = create_job(u'ALPHARD', self.data)
         self.assertIsInstance(job, ShapefileUploadJob)
 
     def testCreateJobCreatesGeoTiffJobFromMimetype(self):
         self.data.mimetype = 'image/tiff'
-        job = create_job(self.data)
+        job = create_job(u'LUPI', self.data)
         self.assertIsInstance(job, GeoTiffUploadJob)
 
     def testCreateJobSetsFailedStatusOnError(self):
         with patch('kepler.jobs.ShapefileUploadJob') as mock:
             mock.side_effect = Exception
             try:
-                create_job(self.data)
+                create_job(u'FROST', self.data)
             except:
                 pass
             self.assertEqual(Job.query.first().status, 'FAILED')
@@ -55,12 +55,12 @@ class JobFactoryTestCase(JobTestCase):
         with patch('kepler.jobs.ShapefileUploadJob') as mock:
             mock.side_effect = AttributeError()
             with self.assertRaises(AttributeError):
-                create_job(self.data)
+                create_job(u'MALRONA', self.data)
 
     def testCreateJobRaisesUnsupportedFormat(self):
         self.data.mimetype = 'application/example'
         with self.assertRaises(UnsupportedFormat):
-            create_job(self.data)
+            create_job(u'BLOODY_VICTORIA', self.data)
 
 
 class UploadJobTestCase(JobTestCase):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -16,20 +16,20 @@ class IngestTestCase(BaseTestCase):
 
     @patch('requests.put')
     @patch('pysolr.Solr.add')
-    def testIngestPostReturns202OnSuccess(self, mock_solr, mock_geoserver):
-        r = self.app.post('/ingest/', upload_files=self.upload_files)
+    def testIngestPutReturns202OnSuccess(self, mock_solr, mock_geoserver):
+        r = self.app.put('/ingest/FOO', upload_files=self.upload_files)
         self.assertEqual(r.status_code, 202)
 
     def testIngestCreatesJob(self):
         with patch('kepler.ingest.views.create_job') as mock:
             instance = mock.return_value
-            self.app.post('/ingest/', upload_files=self.upload_files)
+            self.app.put('/ingest/FOO', upload_files=self.upload_files)
             self.assertTrue(instance.run.called)
 
     def testIngestReturns415OnUnsupportedFormatError(self):
         with patch('kepler.ingest.views.create_job') as mock:
             mock.side_effect = UnsupportedFormat('application/example')
-            r = self.app.post('/ingest/', upload_files=self.upload_files,
+            r = self.app.put('/ingest/FOO', upload_files=self.upload_files,
                               expect_errors=True)
             self.assertEqual(r.status_code, 415)
 
@@ -37,7 +37,7 @@ class IngestTestCase(BaseTestCase):
     @patch('pysolr.Solr.add')
     def testIngestCompletesJobOnSuccess(self, mock_solr, mock_geoserver):
         with patch('kepler.jobs.UploadJob.complete') as mock:
-            self.app.post('/ingest/', upload_files=self.upload_files)
+            self.app.put('/ingest/FOO', upload_files=self.upload_files)
             self.assertTrue(mock.called)
 
     def testIngestFailsJobOnError(self):
@@ -46,7 +46,7 @@ class IngestTestCase(BaseTestCase):
             instance = mock.return_value
             instance.run.side_effect = AttributeError()
             try:
-                self.app.post('/ingest/', upload_files=self.upload_files,
+                self.app.put('/ingest/FOO', upload_files=self.upload_files,
                               expect_errors=True)
             except AttributeError:
                 pass
@@ -58,7 +58,7 @@ class IngestTestCase(BaseTestCase):
         with patch('kepler.ingest.views.create_job') as mock:
             instance = mock.return_value
             instance.run.side_effect = AttributeError()
-            r = self.app.post('/ingest/', upload_files=self.upload_files,
+            r = self.app.put('/ingest/FOO', upload_files=self.upload_files,
                               expect_errors=True)
             self.assertEqual(r.status_code, 500)
 


### PR DESCRIPTION
Switches from POST to PUT for resource creation. The generation of
resource IDs should happen on the client. This allows for more
flexibility in creating jobs since not all ingest jobs will have an
associated file to pull a name out of.