### PR TITLE
Use temporary file for uploaded data

### DIFF
--- a/docs/application.rst
+++ b/docs/application.rst
@@ -1,7 +1,12 @@
-Application Documentation
+Module Documentation
 =========================
 
-SWORD
+kepler
+------
+
+.. autofunction:: kepler.make_tempfile
+
+kepler.sword
 -----
 
 .. automodule:: kepler.sword

--- a/kepler/__init__.py
+++ b/kepler/__init__.py
@@ -1,8 +1,41 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from functools import reduce
+import tempfile
+import os
+
+from werkzeug import secure_filename
 
 
 def compose(*funcs):
     return reduce(lambda f, g: lambda *args, **kwargs: f(g(*args, **kwargs)),
                   funcs)
+
+
+def make_tempfile(data=None):
+    """Create a temporary file and return the path.
+
+    This uses ``tempfile.mkstemp`` from the standard library to create the
+    tempfile. The temporary file will be removed if an exception is raised
+    while trying to write the provided.
+
+    .. note::
+
+        It is up to you to delete the file when you are finished.
+
+    :param data: ``werkzeug.datastructures.FileStorage`` object
+    :return: absolute path to temporary file or ``None`` if no data was provided
+    """
+
+    if not data:
+        return None
+    filename = secure_filename(data.filename)
+    fd, fname = tempfile.mkstemp(suffix="-%s" % filename)
+    fp = os.fdopen(fd, 'wb')
+    try:
+        data.save(fp)
+        fp.close()
+    except:
+        os.remove(fname)
+        raise
+    return fname

--- a/kepler/geoserver.py
+++ b/kepler/geoserver.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import io
 
 import requests
 from flask import current_app
@@ -34,7 +35,8 @@ def delete_url(id, mimetype):
 def put(id, data, mimetype):
     url = put_url(id, mimetype)
     headers = {'Content-type': mimetype}
-    r = requests.put(url, data=data, headers=headers)
+    with io.open(data, 'rb') as fp:
+        r = requests.put(url, data=fp, headers=headers)
     r.raise_for_status()
 
 

--- a/tests/test_geoserver.py
+++ b/tests/test_geoserver.py
@@ -40,15 +40,14 @@ class TestGeoServer(object):
             'http://example.com/geoserver/rest/workspaces/mit/coveragestores/foo?recurse=true'
 
     def testPutUploadsData(self, requests):
-        put('foo', 'bar', 'application/zip')
-        url = put_url('foo', 'application/zip')
-        requests.put.assert_called_once_with(url, data='bar',
-            headers={'Content-type': 'application/zip'})
+        put('foo', 'tests/data/bermuda.zip', 'application/zip')
+        call = requests.put.call_args
+        assert call[1].get('data').name == 'tests/data/bermuda.zip'
 
     def testPutRaisesHttpErrorWhenUnsuccessful(self, requests):
         requests.put.return_value = Mock(**{'raise_for_status.side_effect': HTTPError})
         with pytest.raises(HTTPError):
-            put('foo', 'bar', 'image/tiff')
+            put('foo', 'tests/data/grayscale.tif', 'image/tiff')
 
     def testDeleteDeletesResource(self, requests):
         delete('foo', 'image/tiff')

--- a/tests/test_kepler.py
+++ b/tests/test_kepler.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import os
 
-from kepler import compose
+from mock import Mock
+
+from kepler import compose, make_tempfile
 
 
 class TestKepler(object):
@@ -11,3 +14,21 @@ class TestKepler(object):
         dbl = lambda x: x * 2
         f = compose(dbl, inc, add)
         assert f(1, 2) == 8
+
+
+def testMakeTempfileReturnsNoneForNoData():
+    assert make_tempfile() is None
+
+
+def testMakeTempfileCreatesTempfile():
+    fname = make_tempfile(Mock(filename='foobar.zip'))
+    assert os.path.exists(fname)
+    os.remove(fname)
+
+
+def testMakeTempfileAppendsFilename():
+    fname = make_tempfile(Mock(filename='foobar.zip'))
+    try:
+        assert fname.endswith('-foobar.zip')
+    finally:
+        os.remove(fname)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -32,9 +32,10 @@ def repo(testapp):
 class TestTasks(object):
     @patch('kepler.tasks.put')
     def testUploadToGeoserverUploadsData(self, mock):
-        record, data = Mock(_filename='foo'), Mock()
-        upload_to_geoserver(record, data, 'application/shp')
-        mock.assert_called_once_with('foo', data, 'application/shp')
+        upload_to_geoserver(Mock(_filename='foo'), 'tests/data/bermuda.zip',
+                            'application/shp')
+        mock.assert_called_once_with('foo', 'tests/data/bermuda.zip',
+                                     'application/shp')
 
     def testIndexRecordAddsRecordToSolr(self, pysolr_add):
         record = Mock()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 from datetime import datetime
+import tempfile
+import os
 
 import pytest
 from mock import patch
@@ -15,6 +17,18 @@ def create_job():
     patcher.stop()
 
 
+@pytest.yield_fixture
+def tmpfile():
+    patcher = patch('kepler.job.views.make_tempfile')
+    patched = patcher.start()
+    fd, fname = tempfile.mkstemp(suffix='.zip')
+    patched.return_value = fname
+    yield fname
+    patcher.stop()
+    if os.path.exists(fname):
+        os.remove(fname)
+
+
 class TestJob(object):
     def testJobCreationReturns201OnSuccess(self, testapp, create_job):
         r = testapp.post('/job/', {'uuid': 'foobar', 'type': 'shapefile'},
@@ -25,6 +39,11 @@ class TestJob(object):
         testapp.post('/job/', {'uuid': 'foobar', 'type': 'shapefile'},
                      upload_files=[('file', 'tests/data/bermuda.zip')])
         assert create_job.call_count == 1
+
+    def testCreateRemovesTempFile(self, testapp, create_job, tmpfile):
+        testapp.post('/job/', {'uuid': 'foobar', 'type': 'shapefile'},
+                     upload_files=[('file', 'tests/data/bermuda.zip')])
+        assert os.path.exists(tmpfile) is False
 
     def testJobCreationReturns500OnJobRunError(self, testapp, create_job):
         create_job.side_effect = Exception


### PR DESCRIPTION
This switches to using a path to a temporary file instead of trying
to manage an open file handle.