### PR TITLE
Retrieve GeoTIFF URL

### DIFF
--- a/kepler/models.py
+++ b/kepler/models.py
@@ -40,6 +40,7 @@ class Item(db.Model):
     handle = db.Column(db.Unicode(255))
     access = db.Column(db.Enum(u'Public', u'Restricted'), default=u'Public')
     jobs = db.relationship('Job', backref='item', lazy='dynamic')
+    tiff_url = db.Column(db.Unicode(255))
 
     def __repr__(self):
         return '<Item #%d: %r>' % (self.id, self.uri)

--- a/kepler/settings.py
+++ b/kepler/settings.py
@@ -20,6 +20,7 @@ class TestConfig(DefaultConfig):
     GEOSERVER_RESTRICTED_URL = 'http://example.com/secure-geoserver/'
     GEOSERVER_WORKSPACE = 'mit'
     GEOSERVER_DATASTORE = 'data'
+    OAI_ORE_URL = 'http://example.com/metadata/handle/'
     SOLR_URL = 'http://localhost:8983/solr/geoblacklight/'
     SWORD_SERVICE_URL = 'http://example.com/sword'
     SWORD_SERVICE_USERNAME = 'swordymcswordmuffin'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,6 +107,27 @@ def fgdc(bag):
     return os.path.join(bag, 'data/fgdc.xml')
 
 
+@pytest.fixture
+def oai_ore():
+    with io.open(_fixture_path('oai_ore.xml'), 'r') as fp:
+        resp = fp.read()
+    return resp
+
+
+@pytest.fixture
+def oai_ore_no_tiffs():
+    with io.open(_fixture_path('oai_ore_no_tiffs.xml'), 'r') as fp:
+        resp = fp.read()
+    return resp
+
+
+@pytest.fixture
+def oai_ore_two_tiffs():
+    with io.open(_fixture_path('oai_ore_two_tiffs.xml'), 'r') as fp:
+        resp = fp.read()
+    return resp
+
+
 @pytest.yield_fixture
 def pysolr_add():
     patcher = patch('pysolr.Solr.add')

--- a/tests/fixtures/oai_ore.xml
+++ b/tests/fixtures/oai_ore.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom" xmlns:ore="http://www.openarchives.org/ore/terms/" xmlns:oreatom="http://www.openarchives.org/ore/atom/" xmlns:dcterms="http://purl.org/dc/terms/">
+<atom:id>http://example.com/oai/metadata/handle/1234.5/67890/ore.xml</atom:id>
+<atom:link rel="alternate" href="http://hdl.handle.net/1234.5/67890"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/describes" href="http://example.com/oai/metadata/handle/1234.5/67890/ore.xml"/>
+<atom:link rel="self" href="http://example.com/oai/metadata/handle/1234.5/67890/ore.xml#atom" type="application/atom+xml"/>
+<atom:published>2015-10-28T09:54:24.339-04:00</atom:published>
+<atom:updated>2015-10-28T09:54:24.343-04:00</atom:updated>
+<atom:source>
+    <atom:generator uri="http://example.com/oai">Some Server Somewhere</atom:generator>
+</atom:source>
+<atom:title>This is a title.</atom:title>
+<atom:category scheme="http://www.openarchives.org/ore/terms/" term="http://www.openarchives.org/ore/terms/Aggregation" label="Aggregation"/>
+<atom:category scheme="http://www.openarchives.org/ore/atom/modified" term="2014-05-29T02:26:08.501-04:00"/>
+<atom:category scheme="http://www.dspace.org/objectModel/" term="DSpaceItem" label="DSpace Item"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_cp.jpg.jpg?sequence=5" title="248077_cp.jpg.jpg" type="image/jpeg" length="2393"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_sv.jpg.jpg?sequence=6" title="248077_sv.jpg.jpg" type="image/jpeg" length="2539"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_tm.jpg.jpg?sequence=7" title="248077_tm.jpg.jpg" type="image/jpeg" length="1591"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077.tif?sequence=4" title="248077.tif" type="image/tiff" length="20859226"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_cp.jpg?sequence=1" title="248077_cp.jpg" type="image/jpeg" length="1614753"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_sv.jpg?sequence=2" title="248077_sv.jpg" type="image/jpeg" length="5771544"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_tm.jpg?sequence=3" title="248077_tm.jpg" type="image/jpeg" length="10361"/>
+<oreatom:triples>
+    <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/oai/metadata/handle/1234.5/67890/ore.xml">
+    <rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceItem"/>
+    <dcterms:modified>2014-05-29T02:26:08.501-04:00</dcterms:modified>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_cp.jpg.jpg?sequence=5">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>THUMBNAIL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_sv.jpg.jpg?sequence=6">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>THUMBNAIL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_tm.jpg.jpg?sequence=7">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>THUMBNAIL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077.tif?sequence=4">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>HIDDEN</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_cp.jpg?sequence=1">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>ORIGINAL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_sv.jpg?sequence=2">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>ORIGINAL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_tm.jpg?sequence=3">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>ORIGINAL</dcterms:description>
+</rdf:Description>
+</oreatom:triples>
+</atom:entry>

--- a/tests/fixtures/oai_ore_no_tiffs.xml
+++ b/tests/fixtures/oai_ore_no_tiffs.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom" xmlns:ore="http://www.openarchives.org/ore/terms/" xmlns:oreatom="http://www.openarchives.org/ore/atom/" xmlns:dcterms="http://purl.org/dc/terms/">
+<atom:id>http://example.com/oai/metadata/handle/1234.5/67890/ore.xml</atom:id>
+<atom:link rel="alternate" href="http://hdl.handle.net/1234.5/67890"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/describes" href="http://example.com/oai/metadata/handle/1234.5/67890/ore.xml"/>
+<atom:link rel="self" href="http://example.com/oai/metadata/handle/1234.5/67890/ore.xml#atom" type="application/atom+xml"/>
+<atom:published>2015-10-28T09:54:24.339-04:00</atom:published>
+<atom:updated>2015-10-28T09:54:24.343-04:00</atom:updated>
+<atom:source>
+    <atom:generator uri="http://example.com/oai">Some Server Somewhere</atom:generator>
+</atom:source>
+<atom:title>This is a title.</atom:title>
+<atom:category scheme="http://www.openarchives.org/ore/terms/" term="http://www.openarchives.org/ore/terms/Aggregation" label="Aggregation"/>
+<atom:category scheme="http://www.openarchives.org/ore/atom/modified" term="2014-05-29T02:26:08.501-04:00"/>
+<atom:category scheme="http://www.dspace.org/objectModel/" term="DSpaceItem" label="DSpace Item"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_cp.jpg.jpg?sequence=5" title="248077_cp.jpg.jpg" type="image/jpeg" length="2393"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_sv.jpg.jpg?sequence=6" title="248077_sv.jpg.jpg" type="image/jpeg" length="2539"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_tm.jpg.jpg?sequence=7" title="248077_tm.jpg.jpg" type="image/jpeg" length="1591"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077.tif?sequence=4" title="248077.tif" type="image/tiff" length="20859226"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_cp.jpg?sequence=1" title="248077_cp.jpg" type="image/jpeg" length="1614753"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_sv.jpg?sequence=2" title="248077_sv.jpg" type="image/jpeg" length="5771544"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_tm.jpg?sequence=3" title="248077_tm.jpg" type="image/jpeg" length="10361"/>
+<oreatom:triples>
+    <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/oai/metadata/handle/1234.5/67890/ore.xml">
+    <rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceItem"/>
+    <dcterms:modified>2014-05-29T02:26:08.501-04:00</dcterms:modified>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_cp.jpg.jpg?sequence=5">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>THUMBNAIL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_sv.jpg.jpg?sequence=6">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>THUMBNAIL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_tm.jpg.jpg?sequence=7">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>THUMBNAIL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077.png?sequence=4">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>HIDDEN</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_cp.jpg?sequence=1">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>ORIGINAL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_sv.jpg?sequence=2">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>ORIGINAL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_tm.jpg?sequence=3">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>ORIGINAL</dcterms:description>
+</rdf:Description>
+</oreatom:triples>
+</atom:entry>

--- a/tests/fixtures/oai_ore_two_tiffs.xml
+++ b/tests/fixtures/oai_ore_two_tiffs.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<atom:entry xmlns:atom="http://www.w3.org/2005/Atom" xmlns:ore="http://www.openarchives.org/ore/terms/" xmlns:oreatom="http://www.openarchives.org/ore/atom/" xmlns:dcterms="http://purl.org/dc/terms/">
+<atom:id>http://example.com/oai/metadata/handle/1234.5/67890/ore.xml</atom:id>
+<atom:link rel="alternate" href="http://hdl.handle.net/1234.5/67890"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/describes" href="http://example.com/oai/metadata/handle/1234.5/67890/ore.xml"/>
+<atom:link rel="self" href="http://example.com/oai/metadata/handle/1234.5/67890/ore.xml#atom" type="application/atom+xml"/>
+<atom:published>2015-10-28T09:54:24.339-04:00</atom:published>
+<atom:updated>2015-10-28T09:54:24.343-04:00</atom:updated>
+<atom:source>
+    <atom:generator uri="http://example.com/oai">Some Server Somewhere</atom:generator>
+</atom:source>
+<atom:title>This is a title.</atom:title>
+<atom:category scheme="http://www.openarchives.org/ore/terms/" term="http://www.openarchives.org/ore/terms/Aggregation" label="Aggregation"/>
+<atom:category scheme="http://www.openarchives.org/ore/atom/modified" term="2014-05-29T02:26:08.501-04:00"/>
+<atom:category scheme="http://www.dspace.org/objectModel/" term="DSpaceItem" label="DSpace Item"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_cp.jpg.jpg?sequence=5" title="248077_cp.jpg.jpg" type="image/jpeg" length="2393"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_sv.jpg.jpg?sequence=6" title="248077_sv.jpg.jpg" type="image/jpeg" length="2539"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_tm.jpg.jpg?sequence=7" title="248077_tm.jpg.jpg" type="image/jpeg" length="1591"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077.tif?sequence=4" title="248077.tif" type="image/tiff" length="20859226"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_cp.jpg?sequence=1" title="248077_cp.jpg" type="image/jpeg" length="1614753"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_sv.jpg?sequence=2" title="248077_sv.jpg" type="image/jpeg" length="5771544"/>
+<atom:link rel="http://www.openarchives.org/ore/terms/aggregates" href="http://example.com/bitstream/handle/1234.5/67890/248077_tm.jpg?sequence=3" title="248077_tm.jpg" type="image/jpeg" length="10361"/>
+<oreatom:triples>
+    <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/oai/metadata/handle/1234.5/67890/ore.xml">
+    <rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceItem"/>
+    <dcterms:modified>2014-05-29T02:26:08.501-04:00</dcterms:modified>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_cp.jpg.jpg?sequence=5">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>THUMBNAIL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_sv.jpg.jpg?sequence=6">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>THUMBNAIL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_tm.jpg.jpg?sequence=7">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>THUMBNAIL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077.tif?sequence=4">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>HIDDEN</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_cp.tif?sequence=1">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>ORIGINAL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_sv.jpg?sequence=2">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>ORIGINAL</dcterms:description>
+</rdf:Description>
+<rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://example.com/bitstream/handle/1234.5/67890/248077_tm.jpg?sequence=3">
+<rdf:type rdf:resource="http://www.dspace.org/objectModel/DSpaceBitstream"/>
+<dcterms:description>ORIGINAL</dcterms:description>
+</rdf:Description>
+</oreatom:triples>
+</atom:entry>

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -84,3 +84,7 @@ class TestItem(object):
     def testItemHasHandle(self, db):
         item = Item(handle='http://hdl.handle.net/123456789/3')
         assert item.handle == 'http://hdl.handle.net/123456789/3'
+
+    def testItemHasTiffUrl(self, db):
+        item = Item(tiff_url='http://example.com/bitstream/handle/1234.5/67890/248077.tif?sequence=4')
+        assert item.tiff_url == 'http://example.com/bitstream/handle/1234.5/67890/248077.tif?sequence=4'

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     webtest
     pytest
     mock
+    requests_mock
     -r{toxinidir}/requirements.txt
 
 [testenv:clean]


### PR DESCRIPTION
Initial work on #71

Integrating into the Job task flow remains.

At this time, a specific server from which to retrieve a record based
on a handle is required. It seems theoretically possible to guess the
paths based on the results of a handle redirection, but for our use
case this seemed fine.