### PR TITLE
Add authentication for POST requests

### DIFF
--- a/kepler/__init__.py
+++ b/kepler/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from flask import abort, current_app, request
+
+
+def authenticate_client(username, password):
+    return "%s:%s" % (username, password) == \
+        current_app.config.get('CLIENT_AUTH')
+
+
+def client_auth_required(f):
+    def wrapper(*args, **kwargs):
+        auth = request.authorization
+        if not auth or not authenticate_client(auth.username, auth.password):
+            abort(401)
+        return f(*args, **kwargs)
+    return wrapper

--- a/kepler/layer/views.py
+++ b/kepler/layer/views.py
@@ -8,6 +8,7 @@ import uuid
 from flask import request
 from flask.views import View
 
+from kepler import client_auth_required
 from kepler.bag import unpack, get_datatype, get_access
 from kepler.exceptions import UnsupportedFormat
 from kepler.jobs import create_job
@@ -43,5 +44,5 @@ class LayerView(View):
 
     @classmethod
     def register(cls, app, endpoint, url):
-        view_func = cls.as_view(endpoint)
+        view_func = client_auth_required(cls.as_view(endpoint))
         app.add_url_rule(url, 'resource', methods=['POST'], view_func=view_func)

--- a/kepler/marc/views.py
+++ b/kepler/marc/views.py
@@ -5,6 +5,7 @@ import uuid
 from flask import request
 from flask.views import View
 
+from kepler import client_auth_required
 from kepler.jobs import create_job
 from kepler.tasks import index_marc_records
 
@@ -24,5 +25,5 @@ class MarcView(View):
 
     @classmethod
     def register(cls, app, endpoint, url):
-        view_func = cls.as_view(endpoint)
+        view_func = client_auth_required(cls.as_view(endpoint))
         app.add_url_rule(url, 'resource', methods=['POST'], view_func=view_func)

--- a/kepler/settings.py
+++ b/kepler/settings.py
@@ -42,3 +42,4 @@ class TestConfig(DefaultConfig):
     SWORD_SERVICE_USERNAME = 'swordymcswordmuffin'
     SWORD_SERVICE_PASSWORD = 'vorpalblade'
     UUID_NAMESPACE = 'arrowsmith.mit.edu'
+    CLIENT_AUTH = 'username:password'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,9 @@ def app():
 
 @pytest.fixture
 def testapp(app):
-    return TestApp(app)
+    _app = TestApp(app)
+    _app.authorization = ('Basic', ('username', 'password'))
+    return _app
 
 
 @pytest.yield_fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,19 @@ def app():
 
 @pytest.fixture
 def testapp(app):
+    """A non-authorized test application.
+
+    Use this for GET requests that don't require authentication.
+    """
+    return TestApp(app)
+
+
+@pytest.fixture
+def auth_testapp(app):
+    """An authorized test application.
+
+    Use this for POST requests requiring authentication.
+    """
     _app = TestApp(app)
     _app.authorization = ('Basic', ('username', 'password'))
     return _app

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -28,38 +28,39 @@ def marc_tasks():
 
 
 class TestLayer(object):
-    def testReturns201OnSuccess(self, testapp, geo_tasks, bag_upload):
-        r = testapp.post('/layers/', upload_files=[('file', bag_upload)])
+    def testReturns201OnSuccess(self, auth_testapp, geo_tasks, bag_upload):
+        r = auth_testapp.post('/layers/', upload_files=[('file', bag_upload)])
         assert r.status_code == 201
 
-    def testJobCreated(self, testapp, geo_tasks, bag_upload):
-        r = testapp.post('/layers/', upload_files=[('file', bag_upload)])
+    def testJobCreated(self, auth_testapp, geo_tasks, bag_upload):
+        auth_testapp.post('/layers/', upload_files=[('file', bag_upload)])
         assert Job.query.count() == 1
 
-    def testJobIsRun(self, testapp, geo_tasks, bag_upload):
-        r = testapp.post('/layers/', upload_files=[('file', bag_upload)])
+    def testJobIsRun(self, auth_testapp, geo_tasks, bag_upload):
+        auth_testapp.post('/layers/', upload_files=[('file', bag_upload)])
         assert Job.query.first().status == 'COMPLETED'
 
-    def testRunsShapefileTasks(self, testapp, geo_tasks, bag_upload):
-        r = testapp.post('/layers/', upload_files=[('file', bag_upload)])
+    def testRunsShapefileTasks(self, auth_testapp, geo_tasks, bag_upload):
+        auth_testapp.post('/layers/', upload_files=[('file', bag_upload)])
         assert geo_tasks['upload_shapefile'].called
         assert geo_tasks['index_shapefile'].called
 
-    def testRunsGeotiffTasks(self, testapp, geo_tasks, bag_tif_upload):
-        r = testapp.post('/layers/', upload_files=[('file', bag_tif_upload)])
+    def testRunsGeotiffTasks(self, auth_testapp, geo_tasks, bag_tif_upload):
+        auth_testapp.post('/layers/', upload_files=[('file', bag_tif_upload)])
         assert geo_tasks['upload_geotiff'].called
         assert geo_tasks['submit_to_dspace'].called
         assert geo_tasks['index_geotiff'].called
 
-    def testReturns415OnUnsupportedFormat(self, testapp, geo_tasks, bag_upload):
+    def testReturns415OnUnsupportedFormat(self, auth_testapp, geo_tasks,
+                                          bag_upload):
         with patch('kepler.layer.views.get_datatype') as datatype:
             datatype.return_value = 'w4rez'
-            r = testapp.post('/layers/', upload_files=[('file', bag_upload)],
-                             expect_errors=True)
+            r = auth_testapp.post('/layers/',
+                                  upload_files=[('file', bag_upload)],
+                                  expect_errors=True)
         assert r.status_code == 415
 
     def testReturns401OnNoAuthentication(self, testapp):
-        testapp.authorization = None
         r = testapp.post('/layers/', expect_errors=True)
         assert r.status_code == 401
 
@@ -70,20 +71,19 @@ class TestLayer(object):
 
 
 class TestMarc(object):
-    def testReturns201OnSuccess(self, testapp, marc, marc_tasks):
-        r = testapp.post('/marc/', upload_files=[('file', marc)])
+    def testReturns201OnSuccess(self, auth_testapp, marc, marc_tasks):
+        r = auth_testapp.post('/marc/', upload_files=[('file', marc)])
         assert r.status_code == 201
 
-    def testJobCreated(self, testapp, marc, marc_tasks):
-        r = testapp.post('/marc/', upload_files=[('file', marc)])
+    def testJobCreated(self, auth_testapp, marc, marc_tasks):
+        auth_testapp.post('/marc/', upload_files=[('file', marc)])
         assert Job.query.count() == 1
 
-    def testJobIsRun(self, testapp, marc, marc_tasks):
-        r = testapp.post('/marc/', upload_files=[('file', marc)])
+    def testJobIsRun(self, auth_testapp, marc, marc_tasks):
+        auth_testapp.post('/marc/', upload_files=[('file', marc)])
         assert Job.query.first().status == 'COMPLETED'
 
     def testReturns401OnNoAuthentication(self, testapp):
-        testapp.authorization = None
         r = testapp.post('/marc/', expect_errors=True)
         assert r.status_code == 401
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -58,6 +58,16 @@ class TestLayer(object):
                              expect_errors=True)
         assert r.status_code == 415
 
+    def testReturns401OnNoAuthentication(self, testapp):
+        testapp.authorization = None
+        r = testapp.post('/layers/', expect_errors=True)
+        assert r.status_code == 401
+
+    def testReturns401OnBadAuthentication(self, testapp):
+        testapp.authorization = ('Basic', ('username', 'wat'))
+        r = testapp.post('/layers/', expect_errors=True)
+        assert r.status_code == 401
+
 
 class TestMarc(object):
     def testReturns201OnSuccess(self, testapp, marc, marc_tasks):
@@ -71,6 +81,16 @@ class TestMarc(object):
     def testJobIsRun(self, testapp, marc, marc_tasks):
         r = testapp.post('/marc/', upload_files=[('file', marc)])
         assert Job.query.first().status == 'COMPLETED'
+
+    def testReturns401OnNoAuthentication(self, testapp):
+        testapp.authorization = None
+        r = testapp.post('/marc/', expect_errors=True)
+        assert r.status_code == 401
+
+    def testReturns401OnBadAuthentication(self, testapp):
+        testapp.authorization = ('Basic', ('username', 'foobar'))
+        r = testapp.post('/marc/', expect_errors=True)
+        assert r.status_code == 401
 
 
 class TestJob(object):


### PR DESCRIPTION
Closes #78. This provides Basic Auth for the two POST endpoints
with the username/password being provided through an environment
variable.