### PR TITLE
Initial Logging Setup

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,6 +4,8 @@
     "postdeploy": "python manage.py db upgrade"
   },
   "env": {
+    "GEOSERVER_AUTH_USER": "username",
+    "GEOSERVER_AUTH_PASS": "securepassword",
     "GEOSERVER_DATASTORE": "data",
     "GEOSERVER_PUBLIC_URL": "http://example.com/geoserver/",
     "GEOSERVER_RESTRICTED_URL": "http://example.com/secure-geoserver/",

--- a/kepler/app.py
+++ b/kepler/app.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
+import logging
 from flask import Flask
 from .extensions import db
 from kepler.job import job_blueprint
@@ -15,14 +16,17 @@ def create_app(cfg_obj=None):
     app.config.from_object(DefaultConfig)
     app.config.from_object(cfg_obj)
 
+    register_loggers(app)
     register_extensions(app)
     register_blueprints(app)
     register_errorhandlers(app)
+    app.logger.info("Application Startup Complete")
     return app
 
 
 def register_extensions(app):
     db.init_app(app)
+    app.logger.info("Extensions registered")
 
 
 def register_blueprints(app):
@@ -30,9 +34,33 @@ def register_blueprints(app):
     app.register_blueprint(item_blueprint)
     app.register_blueprint(layer_blueprint)
     app.register_blueprint(marc_blueprint)
+    app.logger.info("Blueprints registered")
 
 
 def register_errorhandlers(app):
     def handle_unsupported_format(error):
         return '', 415
     app.errorhandler(UnsupportedFormat)(handle_unsupported_format)
+    app.logger.info("Error Handlers registered")
+
+
+def register_loggers(app):
+    formatter = logging.Formatter(
+        "[%(asctime)s] [%(name)s] [%(levelname)s] [%(message)s]",
+        datefmt='%Y-%m-%d %H:%M:%S %z')
+
+    logging.getLogger().setLevel(logging.DEBUG)
+
+    # stdout log handler
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    handler.setLevel(logging.DEBUG)
+
+    # general flask app logger
+    app.logger.addHandler(handler)
+
+    # http logging
+    requests_log = logging.getLogger("requests.packages.urllib3")
+    requests_log.setLevel(logging.DEBUG)
+    requests_log.addHandler(handler)
+    app.logger.info("Loggers registered")

--- a/kepler/app.py
+++ b/kepler/app.py
@@ -20,13 +20,13 @@ def create_app(cfg_obj=None):
     register_extensions(app)
     register_blueprints(app)
     register_errorhandlers(app)
-    app.logger.info("Application Startup Complete")
+    app.logger.info('Application Startup Complete')
     return app
 
 
 def register_extensions(app):
     db.init_app(app)
-    app.logger.info("Extensions registered")
+    app.logger.info('Extensions registered')
 
 
 def register_blueprints(app):
@@ -34,20 +34,18 @@ def register_blueprints(app):
     app.register_blueprint(item_blueprint)
     app.register_blueprint(layer_blueprint)
     app.register_blueprint(marc_blueprint)
-    app.logger.info("Blueprints registered")
+    app.logger.info('Blueprints registered')
 
 
 def register_errorhandlers(app):
     def handle_unsupported_format(error):
         return '', 415
     app.errorhandler(UnsupportedFormat)(handle_unsupported_format)
-    app.logger.info("Error Handlers registered")
+    app.logger.info('Error Handlers registered')
 
 
 def register_loggers(app):
-    formatter = logging.Formatter(
-        "[%(asctime)s] [%(name)s] [%(levelname)s] [%(message)s]",
-        datefmt='%Y-%m-%d %H:%M:%S %z')
+    formatter = logging.Formatter("[%(name)s] [%(levelname)s] %(message)s")
 
     logging.getLogger().setLevel(logging.DEBUG)
 
@@ -60,7 +58,7 @@ def register_loggers(app):
     app.logger.addHandler(handler)
 
     # http logging
-    requests_log = logging.getLogger("requests.packages.urllib3")
+    requests_log = logging.getLogger('requests.packages.urllib3')
     requests_log.setLevel(logging.DEBUG)
     requests_log.addHandler(handler)
-    app.logger.info("Loggers registered")
+    app.logger.info('Loggers registered')


### PR DESCRIPTION
This sets the default logger to stdout and uses a format that matches
Heroku.

As external HTTP calls are essential to this app, this logs those at a
fairly basic level. (They happened and the status mostly).

One way to add additional logging is by importing `current_app` from
Flask and doing things like:
`current_app.logger.info(“Logs are my friends.”)`

work on #93 