### PR TITLE
Add support for authenticating to Solr

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,6 +14,8 @@
     "PATH": "/app/.geodjango/gdal/bin:/usr/local/bin:/usr/bin:/bin",
     "SECRET_KEY": "secret",
     "SOLR_URL": "http://localhost:8983/solr/geoblacklight/",
+    "SOLR_AUTH_USER": {"required": true},
+    "SOLR_AUTH_PASS": {"required": true},
     "SWORD_SERVICE_PASSWORD": "vorpalblade",
     "SWORD_SERVICE_URL": "http://example.com/sword",
     "SWORD_SERVICE_USERNAME": "swordymcswordmuffin",

--- a/kepler/settings.py
+++ b/kepler/settings.py
@@ -21,6 +21,8 @@ class HerokuConfig(DefaultConfig):
         self.GEOSERVER_WORKSPACE = os.environ['GEOSERVER_WORKSPACE']
         self.GEOSERVER_DATASTORE = os.environ['GEOSERVER_DATASTORE']
         self.SOLR_URL = os.environ['SOLR_URL']
+        self.SOLR_AUTH_USER = os.environ['SOLR_AUTH_USER']
+        self.SOLR_AUTH_PASS = os.environ['SOLR_AUTH_PASS']
         self.OAI_ORE_URL = os.environ['OAI_ORE_URL']
         self.SWORD_SERVICE_URL = os.environ['SWORD_SERVICE_URL']
         self.SWORD_SERVICE_USERNAME = os.environ['SWORD_SERVICE_USERNAME']

--- a/kepler/tasks.py
+++ b/kepler/tasks.py
@@ -185,7 +185,11 @@ def _index_records(records):
     :param records: iterator of dictionaries to be added to Solr
     """
 
+    auth = (current_app.config.get('SOLR_AUTH_USER'),
+            current_app.config.get('SOLR_AUTH_PASS'))
     solr = pysolr.Solr(current_app.config['SOLR_URL'])
+    if all(auth):
+        solr.auth = auth
     solr.add(records)
 
 


### PR DESCRIPTION
This will use basic auth for communicating with Solr if both a
`SOLR_AUTH_USER` and `SOLR_AUTH_PASS` are set as environment
variables.