### PR TITLE
Convert sets to lists for pysolr

### DIFF
--- a/kepler/__init__.py
+++ b/kepler/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import
 
 from flask import abort, current_app, request
+import requests
 
 
 def authenticate_client(username, password):
@@ -16,3 +17,7 @@ def client_auth_required(f):
             abort(401)
         return f(*args, **kwargs)
     return wrapper
+
+
+solr_session = requests.Session()
+solr_session.stream = False

--- a/kepler/settings.py
+++ b/kepler/settings.py
@@ -42,7 +42,7 @@ class TestConfig(DefaultConfig):
     GEOSERVER_WORKSPACE = 'mit'
     GEOSERVER_DATASTORE = 'data'
     OAI_ORE_URL = 'http://example.com/metadata/handle/'
-    SOLR_URL = 'http://localhost:8983/solr/geoblacklight/'
+    SOLR_URL = 'mock://localhost:8983/solr/geoblacklight/'
     SWORD_SERVICE_URL = 'http://example.com/sword'
     SWORD_SERVICE_USERNAME = 'swordymcswordmuffin'
     SWORD_SERVICE_PASSWORD = 'vorpalblade'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ import shutil
 import pytest
 from webtest import TestApp
 from mock import patch, Mock
+import requests
+import requests_mock
 
 from kepler.app import create_app
 from kepler.extensions import db as _db
@@ -144,9 +146,12 @@ def oai_ore_two_tiffs():
 
 
 @pytest.yield_fixture
-def pysolr_add():
-    patcher = patch('pysolr.Solr.add')
-    yield patcher.start()
+def pysolr():
+    adapter = requests_mock.Adapter()
+    patcher = patch('kepler.solr_session', new_callable=requests.Session)
+    sess = patcher.start()
+    sess.mount('mock', adapter)
+    yield adapter
     patcher.stop()
 
 


### PR DESCRIPTION
Pysolr does not work with sets for multivalues fields, so these need
to be converted to lists. This commit also uses a package-level
requests session object for the solr request, mostly for ease of
testing.