### PR TITLE
Fix url generation for OGC services

### DIFF
--- a/kepler/geoserver.py
+++ b/kepler/geoserver.py
@@ -7,11 +7,11 @@ from flask import current_app
 
 
 def wms_url(access):
-    return '%swms' % _url_by_access(access)
+    return '%s/wms' % _url_by_access(access).rstrip('/')
 
 
 def wfs_url(access):
-    return '%swfs' % _url_by_access(access)
+    return '%s/wfs' % _url_by_access(access).rstrip('/')
 
 
 def service_url(root_url, workspace):

--- a/tests/test_geoserver.py
+++ b/tests/test_geoserver.py
@@ -62,6 +62,26 @@ class TestGeoServer(object):
         assert wfs_url('Public') == 'http://example.com/geoserver/wfs'
         assert wfs_url('Restricted') == 'http://example.com/secure-geoserver/wfs'
 
+    def test_wms_url_works_without_trailing_slash(self):
+        with patch('kepler.geoserver._url_by_access') as m:
+            m.return_value = 'http://example.com/secure'
+            assert wms_url('Public') == 'http://example.com/secure/wms'
+
+    def test_wms_url_works_with_trailing_slash(self):
+        with patch('kepler.geoserver._url_by_access') as m:
+            m.return_value = 'http://example.com/secure/'
+            assert wms_url('Public') == 'http://example.com/secure/wms'
+
+    def test_wfs_url_works_without_trailing_slash(self):
+        with patch('kepler.geoserver._url_by_access') as m:
+            m.return_value = 'http://example.com/secure'
+            assert wfs_url('Public') == 'http://example.com/secure/wfs'
+
+    def test_wfs_Url_works_with_trailing_slash(self):
+        with patch('kepler.geoserver._url_by_access') as m:
+            m.return_value = 'http://example.com/secure/'
+            assert wfs_url('Public') == 'http://example.com/secure/wfs'
+
     def testServiceUrlGeneratesUrl(self):
         assert service_url(root, 'foo') == '%srest/workspaces/foo/' % root
 


### PR DESCRIPTION
This ensures the correct wms/wfs url is used whether or not the
GeoServer url is set with or without a trailing slash. Fixes #105.