### PR TITLE
Use correct layer id for shapefiles

### DIFF
--- a/kepler/bag.py
+++ b/kepler/bag.py
@@ -16,6 +16,15 @@ def get_shapefile(bag):
     return _extract_data(bag, '.zip')
 
 
+def get_shapefile_name(bag):
+    shp = get_shapefile(bag)
+    with ZipFile(shp) as zf:
+        files = zf.namelist()
+    for f in files:
+        if f.endswith('.shp'):
+            return f.rstrip('.shp')
+
+
 def get_geotiff(bag):
     return _extract_data(bag, '.tif')
 

--- a/tests/test_bag.py
+++ b/tests/test_bag.py
@@ -28,6 +28,10 @@ def test_returns_shapefile_path(bag):
     assert get_shapefile(bag) == "%sdata/shapefile.zip" % bag
 
 
+def test_returns_shapefile_name(bag):
+    assert get_shapefile_name(bag) == 'SDE_DATA_BD_A8GNS_2003'
+
+
 def test_unpacks_bag(bag_upload):
     tmp = tempfile.mkdtemp()
     unpack(bag_upload, tmp)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -31,7 +31,9 @@ def testIndexShapefileIndexesFromFGDC(job, bag):
     }
     with patch('kepler.tasks._index_from_fgdc') as mock:
         index_shapefile(job, bag)
-        mock.assert_called_with(job, bag=bag, dct_references_s=refs)
+        mock.assert_called_with(job, bag=bag, dct_references_s=refs,
+                                uuid='c8921f5a-eac7-509b-bac5-bd1b2cb202dc',
+                                layer_id_s='mit:SDE_DATA_BD_A8GNS_2003')
 
 
 def testIndexGeotiffIndexesFromFGDC(job, bag):
@@ -42,7 +44,9 @@ def testIndexGeotiffIndexesFromFGDC(job, bag):
     job.item.tiff_url = 'http://example.com/foobar'
     with patch('kepler.tasks._index_from_fgdc') as mock:
         index_geotiff(job, bag)
-        mock.assert_called_with(job, bag=bag, dct_references_s=refs)
+        mock.assert_called_with(job, bag=bag, dct_references_s=refs,
+                                uuid='c8921f5a-eac7-509b-bac5-bd1b2cb202dc',
+                                layer_id_s='mit:c8921f5a-eac7-509b-bac5-bd1b2cb202dc')
 
 
 def testSubmitToDspaceUploadsSwordPackage(job, bag_tif):
@@ -130,23 +134,11 @@ def testUploadGeotiffPyramidsTiff(job, bag_tif):
 
 def testIndexFromFgdcCreatesRecord(job, bag):
     with patch('kepler.tasks._index_records') as mock:
-        _index_from_fgdc(job, bag)
+        _index_from_fgdc(job, bag, layer_id_s='mit:SDE_DATA_BD_A8GNS_2003',
+                         uuid='c8921f5a-eac7-509b-bac5-bd1b2cb202dc')
         args = mock.call_args[0]
     assert args[0][0].get('dc_title_s') == 'Bermuda (Geographic Feature Names, 2003)'
-
-
-def testIndexFromFgdcAddsLayerId(job, bag):
-    with patch('kepler.tasks._index_records') as mock:
-        _index_from_fgdc(job, bag)
-        args = mock.call_args[0]
-    assert args[0][0].get('layer_id_s') == 'mit:c8921f5a-eac7-509b-bac5-bd1b2cb202dc'
-
-
-def testIndexFromFgdcAddsUuid(job, bag):
-    with patch('kepler.tasks._index_records') as mock:
-        _index_from_fgdc(job, bag)
-        args = mock.call_args[0]
-    assert args[0][0].get('uuid') == 'c8921f5a-eac7-509b-bac5-bd1b2cb202dc'
+    assert args[0][0].get('layer_id_s') == 'mit:SDE_DATA_BD_A8GNS_2003'
 
 
 def testUploadToGeoserverUploadsData(job, shapefile):


### PR DESCRIPTION
Fixes #109. This change uses the name of the shapefile to create the
layer_id_s field.