### PR TITLE
Allow more permissive FGDC file naming

### DIFF
--- a/kepler/bag.py
+++ b/kepler/bag.py
@@ -9,7 +9,7 @@ from kepler.records import rights_mapper
 
 
 def get_fgdc(bag):
-    return _extract_data(bag, 'fgdc.xml')
+    return _extract_data(bag, '.xml')
 
 
 def get_shapefile(bag):


### PR DESCRIPTION
This will now allow for the FGDC file to be named anything as long
as it ends in .xml.