### PR TITLE
Add import checker

### DIFF
--- a/import_check.py
+++ b/import_check.py
@@ -1,0 +1,13 @@
+# -*- encoding: utf-8 -*-
+from __future__ import absolute_import
+
+from kepler.app import create_app
+from kepler.extensions import req
+from kepler.settings import HerokuConfig
+from kepler.tasks import resolve_pending_jobs
+
+
+if __name__ == '__main__':
+    app = create_app(HerokuConfig())
+    with app.app_context():
+        req.q.enqueue(resolve_pending_jobs)


### PR DESCRIPTION
This adds a task to poll GeoServer for the status of an import task and
updates the job if the import has been completed. The `import_check.py`
script will queue this task to be run by the RQ worker. It's intended to
be run regularly on a cron or similar.