### PR TITLE
Fail jobs with failed imports

### DIFF
--- a/kepler/tasks.py
+++ b/kepler/tasks.py
@@ -172,12 +172,15 @@ def resolve_pending_jobs():
                          Job.time == sub_q.c.time)).\
         order_by(Job.time.desc())
     for job in q.filter(Job.status == 'PENDING'):
-        r = geo_session.get(job.import_url)
-        r.raise_for_status()
-        state = r.json()['import']['state']
-        if state == 'COMPLETE':
-            job.status = 'COMPLETED'
-            db.session.commit()
+        try:
+            r = geo_session.get(job.import_url)
+            r.raise_for_status()
+            state = r.json()['import']['state']
+            if state == 'COMPLETE':
+                job.status = 'COMPLETED'
+        except:
+            job.status = 'FAILED'
+        db.session.commit()
 
 
 def index_marc_records(job, data):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -30,6 +30,7 @@ def geo_mock():
               json={'import': {'state': 'COMPLETE'}})
         m.get('/geoserver/rest/imports/1',
               json={'import': {'state': 'WORKING'}})
+        m.get('/geoserver/rest/imports/2', status_code=404)
         yield m
 
 
@@ -170,6 +171,14 @@ def test_resolve_pending_resolves_only_last_job_for_item(job, db, geo_mock):
     resolve_pending_jobs()
     assert job.status == 'PENDING'
     assert job2.status == 'COMPLETED'
+
+
+def test_resolve_pending_fails_jobs_with_exceptions(job, db, geo_mock):
+    job.import_url = 'mock://example.com/geoserver/rest/imports/2'
+    job.status = 'PENDING'
+    db.session.commit()
+    resolve_pending_jobs()
+    assert job.status == 'FAILED'
 
 
 def testIndexFromFgdcCreatesRecord(job, bag):


### PR DESCRIPTION
When the `resolve_pending_jobs` task encounters an exception with the
import, the job status should be set to failed.