### PR TITLE
Cleanup finished geoserver imports

### DIFF
--- a/kepler/tasks.py
+++ b/kepler/tasks.py
@@ -192,6 +192,8 @@ def resolve_pending_jobs():
             job.status = 'FAILED'
             job.error_msg = traceback.format_exc()
         db.session.commit()
+        if job.status in ('COMPLETED', 'FAILED'):
+            geo_session.delete(job.import_url)
 
 
 def index_marc_records(job, data):


### PR DESCRIPTION
Closes #138. Geoserver imports are deleted if they have finished either
successfully or not.